### PR TITLE
Fix memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fix memory leak in NimBLE by calling clearResults after scan results are processed.
+- Use unit64_t for address (device id) instead of std::string
+- Fix several clang tidy issues
+- Update example to call keepAlive regularly. This ensures scanning does not stop due to errors.
+
 ## [0.1.0] 
 ### Added
 - Initial release

--- a/examples/GetLiveValues/GetLiveValues.ino
+++ b/examples/GetLiveValues/GetLiveValues.ino
@@ -15,11 +15,14 @@ void setup() {
 
 void loop() {
     std::map<uint16_t, std::vector<Measurement>> scanResults;
+
     delay(1000);
 
     sensiScan.getScanResults(scanResults);
-
     printScanResults(scanResults);
+
+    // ensure scanning is restarted in case of errors.
+    sensiScan.keepAlive();
 }
 
 void printScanResults(

--- a/src/NimBleClient.cpp
+++ b/src/NimBleClient.cpp
@@ -50,6 +50,9 @@ void NimBleClient::onResult(NimBLEAdvertisedDevice* advertisedDevice) {
     std::string manufacturerData = advertisedDevice->getManufacturerData();
 
     _callback->onAdvertisementReceived(address, name, manufacturerData);
+
+    // clear NIMBle scan results to avoid memory leak.
+    _bleScan->clearResults();
 }
 
 void NimBleClient::setupBleScans() {


### PR DESCRIPTION
Clear cache after scan results are received to ensure internal cache is freed once we processed all scan results of interest.